### PR TITLE
Patch 1 (first pull request)

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -46,7 +46,7 @@
  		"requiredTech": "Industrialization",
  		"uniques": ["Only available <in cities without a [Industrial Relocation]>", "Destroyed when the city is captured", 
       "[-10]% Unhappiness from [Population] [in all cities]", "[+2 Happiness] [in all cities]",
-      "[-2 Happiness] [in all cities] <with [50]% chance>", "Can only be built [in capital]"] 
+      "[-2 Happiness] [in all cities] <with [50]% chance>", "Can only be built <in [in capital] cities>"] 
 },
 { 		
 "name": "Industrial Relocation",
@@ -57,7 +57,7 @@
  		"maintenance": 2, 		
       "requiredTech": "Industrialization",
  		"uniques": ["Only available <in cities without a [Propaganda]>",
- "Can only be built [in capital]",
+ "Can only be built <in [in capital] cities>",
  "Destroyed when the city is captured",
  "[+7]% [Production] [in all cities]"
         ] 
@@ -113,13 +113,13 @@
  		"uniques": [
         "Provides [4] [Gems]",
   "Must have an owned [Crystal Drill] within [3] tiles",
- "Can only be built [in capital]",
+ "Can only be built <in [in capital] cities>",
  "[+1 Happiness] [in all cities]",
  "[+10]% [Production] [in all cities]"
         ] 
 },
 { 		
-"name": "Starlights House",
+"name": "Starlight's House",
  "cost": 130,
  "uniqueTo": "Our Town",
  		"happiness": 3,
@@ -127,7 +127,7 @@
  		"maintenance": 2, 		
       "requiredTech": "Construction",
  		"uniques": [
- "Can only be built [in capital]",
+ "Can only be built <in [in capital] cities>",
  "[+10]% [Production] [in capital]",
  "Destroyed when the city is captured",
         ] 
@@ -154,7 +154,7 @@
  		"requiredTech": "Magical Theory",
  		"uniques": [
         "Destroyed when the city is captured",
-        "Can only be built [in capital]",
+        "Can only be built <in [in capital] cities>",
     ] 
 },
 { 		

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -24,7 +24,7 @@
    "favoredReligion": "Alicornism",	
 	
    "uniqueName": "Harmony",		
-   "uniques": ["[+8 Happiness] [in all cities]", "[+15]% [Happiness] [in all cities] <when not at war>", "City-State territory always counts as friendly territory", "[30]% of excess happiness converted to [Culture] <when not at war>", "[+10]% Strength for cities <when attacking>", "[-20]% City-State Influence degradation", "Ponies", "Non-Griffonians"],		
+   "uniques": ["[+8 Happiness] [in all cities]", "[+15]% [Happiness] [in all cities] <when not at war>", "City-State territory always counts as friendly territory", "[30]% of excess happiness converted to [Culture] <when not at war>", "[+10]% Strength for cities <when attacking>", "[-20]% City-State Influence degradation", "Ponies"],		
    "cities": ["Canterlot","Cloudsdale","Las Pegasus","Hayston","Fillydelphia","Sire's Hollow","Raspberry Grove","Vanhoover","Whitebell","Acornage",			
    "Mariposa","Marechester","Mareway","New Horselean","Marehattan","Canterbury","Stableside","Portland","Prance","Ponyville",			
    "Castle of the Two Sisters","Bales","Luna Nova","Hoofington","Buckcastle","Ghastly Gorge","Trotland","Hoof City","Pinto Creek","Fort Mourn"],
@@ -98,7 +98,7 @@
    "favoredReligion": "Alicornism",	
 	
    "uniqueName": "Ancients of the Jungle",		
-   "uniques": ["[1] Movement <for [Land] units> <in [Jungle] tiles>", "[+10]% Strength <for [Military] units> <when fighting in [Jungle] tiles>", "[+2 Science] from every [{unimproved} {Jungle}]", "[+30]% Strength <for [Land] units> <when defending> <in [Jungle] tiles>", "[+40]% [Science] <during a Golden Age>", "[+2 Science] per [3] population [in all cities]", "Ponies", "Non-Griffonians"],		 
+   "uniques": ["[1] Movement <for [Land] units> <in [Jungle] tiles>", "[+10]% Strength <for [Military] units> <when fighting in [Jungle] tiles>", "[+2 Science] from every [{unimproved} {Jungle}]", "[+30]% Strength <for [Land] units> <when defending> <in [Jungle] tiles>", "[+40]% [Science] <during a Golden Age>", "[+2 Science] per [3] population [in all cities]", "Ponies"],		 
    "cities": ["Saltmare","Tonaltzintili","Tenochtitlan","Ayacachtli","Mareidian","Saltlickingham","Portland","Stableside","Rosemarein","New Mareico",			
    "Coltbla","Guadalamarea","Colterrey","Mareico City","Mareicali","Saint Luis Ponyusi","Mazaztlan","Aztlan City","Old Aztlan","Zebrapan",			
    "Ponechuca","Trotcoco","Zebracala"],
@@ -135,7 +135,7 @@
    "favoredReligion": "Equalism",	
 	
    "uniqueName": "Colony of the Mountains",		
-   "uniques": ["Griffonians", "Non-Ponies", "Land units may cross [Mountain] tiles after the first [Melee] is earned", "[+1 Gold] from every [Mountain]", "[1] Happiness from each type of luxury resource", "[+15 Gold, +5 Production, +3 Culture] [in puppeted cities]", "[+30]% [Production] [in puppeted cities]",  "[+3 Gold, +2 Culture, +1 Happiness] from [Luxury resource] tiles [in puppeted cities]", "[-30]% Unhappiness from [Population] [in puppeted cities]"],	
+   "uniques": ["Griffonians", "Land units may cross [Mountain] tiles after the first [Melee] is earned", "[+1 Gold] from every [Mountain]", "[1] Happiness from each type of luxury resource", "[+15 Gold, +5 Production, +3 Culture] [in puppeted cities]", "[+30]% [Production] [in puppeted cities]",  "[+3 Gold, +2 Culture, +1 Happiness] from [Luxury resource] tiles [in puppeted cities]", "[-30]% Unhappiness from [Population] [in puppeted cities]"],	
    "cities": ["Weter","Zelkshed Skall","Boreasfjord","Nouveau Aquila","Ny Winghagen","Nieuw Mirabell","Moron","Kluv Khot","Bounnois","Federstadt",			
    "Guidonuovo","Tsasbaatar","Groenstein","Fronsthill"],
 },
@@ -162,7 +162,7 @@
    "favoredReligion": "Christianity",	
 	
    "uniqueName": "Home, Sweet Home",		
-   "uniques": ["[+20]% Strength <for [Gunpowder] units> <when fighting in [Friendly] tiles>","[+10]% [Happiness] [in all cities] <with [Apples]>", "Ponies", "Non-Griffonians"],		
+   "uniques": ["[+20]% Strength <for [Gunpowder] units> <when fighting in [Friendly] tiles>","[+10]% [Happiness] [in all cities] <with [Apples]>", "Ponies"],		
    "cities": ["Appleloosa","Trotgaron","Haystin","Foaledo","Jamtown","San Manetonio","Horston","Galloprey","Rosemarein","Marellas",			
    "Lubbuck","Maredessa","Buckston","Maneton Rougue","New Mareleans","Marrahasse","Mareami","Bucksonville","Marelanta","Maregomery",			
    "Little Buck","Balefire","Maneleigh","Fillyville","Buckphis","Marelotte","El Mareo","Maredo","Buckus Mari","Beaumount"],
@@ -200,10 +200,10 @@ Upon declaring war on any major Civilization, gain 150% [Production] in all citi
 */
  "[+10]% Strength <for [Melee] units> <when fighting in [Foreign] tiles> <hidden from users>", 
 
-"[+5]% [Production] [in all cities] <when at war> <hidden from users>", "[+8]% Strength <for [Military] units> <when fighting in [Forest] tiles> <hidden from users>", "[+1 Production] from every [Hive] <when at war> <hidden from users>", "Gain [100] [Gold] <upon conquering a city> <hidden from users>", "Gain [50] [Science] <upon conquering a city> <hidden from users>", "[+1 Food] [in capital] <upon conquering a city> <hidden from users>", "[-10]% [Happiness] <when not at war> <hidden from users>", "Earn [15]% of killed [Military] unit's [Strength] as [Gold] <hidden from users>", "[+60]% [Production] <when at war>", "Free [Infiltrator] appears <upon conquering a city> <after adopting [Infiltration]> <hidden from users>", "[+5]% [Production] from every [Hive] <when at war> <hidden from users>", "[+2]% [Production] from every [Forest] <when at war>", "[+100]% maintenance costs <hidden from users>", "[-70]% Production when constructing [All] buildings [in all cities] <hidden from users>", "Changelings", "Non-Griffonians" 
+"[+5]% [Production] [in all cities] <when at war> <hidden from users>", "[+8]% Strength <for [Military] units> <when fighting in [Forest] tiles> <hidden from users>", "[+1 Production] from every [Hive] <when at war> <hidden from users>", "Gain [100] [Gold] <upon conquering a city> <hidden from users>", "Gain [50] [Science] <upon conquering a city> <hidden from users>", "[+1 Food] [in capital] <upon conquering a city> <hidden from users>", "[-10]% [Happiness] <when not at war> <hidden from users>", "Earn [15]% of killed [Military] unit's [Strength] as [Gold] <hidden from users>", "[+60]% [Production] <when at war>", "Free [Infiltrator] appears <upon conquering a city> <after adopting [Infiltration]> <hidden from users>", "[+5]% [Production] from every [Hive] <when at war> <hidden from users>", "[+2]% [Production] from every [Forest] <when at war>", "[+100]% maintenance costs <hidden from users>", "[-70]% Production when constructing [All] buildings [in all cities] <hidden from users>", "Changelings"
     ] ,
      //"Discover [Leader Assigned] <upon gaining a /[Queen Chrysalis] unit>",
- //"Non-Ponies", "[3] Movement <for [Land] units> <upon gaining a [Queen Chrysalis] unit>", "Free [Choose Your Leader] appears", 
+ //"[3] Movement <for [Land] units> <upon gaining a [Queen Chrysalis] unit>", "Free [Choose Your Leader] appears", 
 
 		
    "cities": ["Vesalipolis","Vraks","Soryth","Dirtysium","Sicarus","Antax","Gardis","Kladisum","Lyctida","Gorak",			
@@ -228,7 +228,7 @@ Upon declaring war on any major Civilization, gain 150% [Production] in all citi
 "innerColor": [237,245,35],		
 "favoredReligion": "Equalism",		
 "uniqueName": "The Collective",		
-"uniques": ["[+7]% [Production] [in all cities] <after discovering [Industrialization]>", "[-25]% maintenance costs <for [Land] units>", "[-25]% Strength <for [Land] units>", "[+1 Production] from every [Tundra]", "[10]% of excess happiness converted to [Production]", "Damage is ignored when determining unit Strength <when attacking>", "Ponies", "Non-Griffonians"],		
+"uniques": ["[+7]% [Production] [in all cities] <after discovering [Industrialization]>", "[-25]% maintenance costs <for [Land] units>", "[-25]% Strength <for [Land] units>", "[+1 Production] from every [Tundra]", "[10]% of excess happiness converted to [Production]", "Damage is ignored when determining unit Strength <when attacking>", "Ponies"],		
 "cities": ["Stalliongrad","Konzan","Zayask","Zlatotsvet","Hoofbeat Town","Caramel Marks","Krasivsk","Altytown","Ravenskoye","Stavropon","Tailney","Saint Petershoof","Altytown","Red Wheat","Novnikovo","Korki","Sovyenok","Zayatsk","Griffimsk"]
 	}, 
 {		
@@ -261,7 +261,7 @@ Gain a 10% Strength bonus to ALL millitary units when above 10 [Gems], then anot
 
      Gain 2 [Faith], and 3 [Culture], frome every worked [Gems] tile inside your territories",
      
-"uniques": ["[+3]% [Production] from every [Gems] <hidden from users>", "[+1 Happiness] from every [Gemstones] <hidden from users>", "[+2 Faith, +3 Culture] from every [Gems] <hidden from users>", "[+1 Happiness] from every [Gems] <hidden from users>", "[+5]% Strength <for [Military] units> <when above [20] [Gems]>", "[+5]% Strength <for [Military] units> <when above [15] [Gems]>", "[+10]% Strength <for [Military] units> <when above [10] [Gems]>", "[1] Movement <in [Crystallization] tiles>", "[+1]% [Culture] from every [Crystallization] <when above [5] [Gems]> <in cities with a [Crystal Maker]>", "[+1]% [Happiness] from every [Crystallization] <when above [5] [Gems]> <in cities with a [Crystal Heart]>", "Ponies", "Non-Griffonians"]
+"uniques": ["[+3]% [Production] from every [Gems] <hidden from users>", "[+1 Happiness] from every [Gemstones] <hidden from users>", "[+2 Faith, +3 Culture] from every [Gems] <hidden from users>", "[+1 Happiness] from every [Gems] <hidden from users>", "[+5]% Strength <for [Military] units> <when above [20] [Gems]>", "[+5]% Strength <for [Military] units> <when above [15] [Gems]>", "[+10]% Strength <for [Military] units> <when above [10] [Gems]>", "[1] Movement <in [Crystallization] tiles>", "[+1]% [Culture] from every [Crystallization] <when above [5] [Gems]> <in cities with a [Crystal Maker]>", "[+1]% [Happiness] from every [Crystallization] <when above [5] [Gems]> <in cities with a [Crystal Heart]>", "Ponies"]
 "cities": ["Crystal City","Rainbow Falls","Rubrum","Porridge Town","Quebuck","Snowybury","Hedgewards","Canterine","Evergreen","Saraneighvo","Emeraldtop","Ponytown", "Shinyronto", "Crystalpeg", "Buckawa", "Princesston", "Candence"]
 	},
 //+1% [Culture] from every [Crystallization] tiles in cities that have a [Crystal Maker]. 
@@ -288,7 +288,7 @@ Gain a 10% Strength bonus to ALL millitary units when above 10 [Gems], then anot
 "innerColor": [121, 125, 126],		
 "favoredReligion": "Hinduism",		
 "uniqueName": "Och vidare, Olenia!",		
-"uniques": ["[+12]% Strength <for [Sword] units> <before the [Renaissance era]>", "[+10]% [Production] [in all coastal cities]", "[+10]% [Production] [in all cities] <for [Water] units>", "[+10]% Strength <for [Water] units> <when fighting in [Coast] tiles>", "Enables [Water] units to enter ocean tiles <upon discovering [Optics]>", "Free [Trireme] appears <upon entering a Golden Age> <before discovering [Compass]>", "Free [Mooseship] appears <upon constructing [All]> <before the [Industrial era]> <after discovering [Compass]> <during a Golden Age> <for [30] turns>", "[2] free [Mooseship] units appear <upon entering a Golden Age> <after discovering [Compass]> <before the [Industrial era]>", "[+1 Faith, +1 Culture] from every [Fishing Boats]", "Non-Ponies", "Non-Griffonians"]
+"uniques": ["[+12]% Strength <for [Sword] units> <before the [Renaissance era]>", "[+10]% [Production] [in all coastal cities]", "[+10]% [Production] [in all cities] <for [Water] units>", "[+10]% Strength <for [Water] units> <when fighting in [Coast] tiles>", "Enables [Water] units to enter ocean tiles <upon discovering [Optics]>", "Free [Trireme] appears <upon entering a Golden Age> <before discovering [Compass]>", "Free [Mooseship] appears <upon constructing [All]> <before the [Industrial era]> <after discovering [Compass]> <during a Golden Age> <for [30] turns>", "[2] free [Mooseship] units appear <upon entering a Golden Age> <after discovering [Compass]> <before the [Industrial era]>", "[+1 Faith, +1 Culture] from every [Fishing Boats]"]
 "cities": ["Hjortland","Endräkt","Seaddle","Älgstad","Hejna","Mantyreek","Vaverfront","Sitz","Equadoe","Goldenshor","Kesäpuoli","Sakara","Luxbucht","Oslott","Elksburg","Isham","Cervus","Hirvikaupunki","Hovenhamn","Snollinga","Svenholm"]
 	}, 
 /* Only shoulf exist as a CS
@@ -312,7 +312,7 @@ Gain a 10% Strength bonus to ALL millitary units when above 10 [Gems], then anot
 "innerColor": [80,84,109],		
 "favoredReligion": "Equalism",		
 "uniqueName": "Down with the Hierachy!",		
-"uniques": ["[+12]% Strength <for [Gunpowder] units> <when fighting in [Friendly] tiles>", "[+12]% Strength <for [GunpowderMagic] units> <when fighting in [Friendly] tiles>", "Ponies", "Non-Griffonians"]
+"uniques": ["[+12]% Strength <for [Gunpowder] units> <when fighting in [Friendly] tiles>", "[+12]% Strength <for [GunpowderMagic] units> <when fighting in [Friendly] tiles>", "Ponies"]
 "cities": ["Our Town","Nash gorod","My Town","Starlight's Town","Glimmer's Town","Your Town","Equal Town","Our Village","My Village","Sunset's Town","Trixie's Trailer","Equal Village","Gorod Starlayt","Gorod Glimmera","Nobody's Town","Ravnyy","Mine.","Hideout","Not Your Town","Everybody's Town","Basic Town"]
 	}, 
 */
@@ -337,7 +337,7 @@ Gain a 10% Strength bonus to ALL millitary units when above 10 [Gems], then anot
 "innerColor": [255,255,255],		
 "favoredReligion": "Christianity",		
 "uniqueName": "Polar Bear Temper",		
-"uniques": ["[+10]% Strength <for [Military] units> <when fighting in [Tundra] tiles>", "[+15]% Strength <for [Military] units> <when fighting in [Snow] tiles>", "[+1 Food, +1 Faith] from every [Snow]", "[+1 Faith, +1 Gold] from every [Tundra]", "Non-Ponies", "Arctic Nations", "Non-Griffonians"]
+"uniques": ["[+10]% Strength <for [Military] units> <when fighting in [Tundra] tiles>", "[+15]% Strength <for [Military] units> <when fighting in [Snow] tiles>", "[+1 Food, +1 Faith] from every [Snow]", "[+1 Faith, +1 Gold] from every [Tundra]", "Arctic Nations"]
 "cities": ["Mathair Fearainn","Polarhill","Pawtovik","Winteryearbypaw","Pawrtic","Polskcow","Coldlaska","Hyper Pawrea","Polarberia","Saint Petersbearg","Winter-on-Don","Chilsk","Wintmara","Paznhy Clavgorod","Beaonezh","Snorilsk","Furchi","Flufbent","Furza","Winta","Santangelsk"]
 	},
 /*
@@ -373,7 +373,7 @@ Gain a 10% Strength bonus to ALL millitary units when above 10 [Gems], then anot
    "favoredReligion": "Christianity",	
 	
    "uniqueName": "The Grand Artic",		
-   "uniques": ["Arctic Nations", "Non-Griffonians", "Non-Ponies", "[+1 Food, +1 Gold] from every [Coast]", "[+1 Culture] from every [Ice]", "[+1 Food] from every [Snow]","[+1 Food] from every [Tundra]", "[-1 Food] from every [{non-[Tundra]}]"],	
+   "uniques": ["Arctic Nations", "[+1 Food, +1 Gold] from every [Coast]", "[+1 Culture] from every [Ice]", "[+1 Food] from every [Snow]","[+1 Food] from every [Tundra]", "[-1 Food] from every [{non-[Tundra]}]"],	
    "cities": ["Dachaigh","Amundsen","Ransen","Ingstad","Sverbruv","Fearann U Deas","Chimincollie","Pingat","Glaser","Iceburg",			
    "Fishiville","Island Up North","Frostile","Wicenstoll"],
 },

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -24,14 +24,14 @@
 {
  "name": "Strategic Infiltration", 
 "uniques": [ "[-10]% [Production] [in all cities] <for [Infiltrator] units>", "Comment [Increases Sight of Infiltrator Units]", "[+1] Sight <for [Infiltrator] units>", "Only available <before adopting [Tactical Infiltration]>"], 
-"row": 3, 
+"row": 2, 
 "column": 1,
 "requires": ["Infiltrater Company"],
 },
 {
  "name": "Chameleon Cloaks", 
 "uniques": [ "[-15]% [Production] [in all cities] <for [Infiltrator] units>", "[+15]% Strength <when fighting in [Forest] tiles>"], 
-"row": 5, 
+"row": 3, 
 "column": 1,
 "requires": ["Strategic Infiltration"],
 },
@@ -39,14 +39,14 @@
 {
  "name": "Tactical Infiltration", 
 "uniques": [ "[+10]% [Production] [in all cities] <for [Infiltrator] units>", "Comment [Strengthens Infiltrator Units]", "Only available <before adopting [Strategic Infiltration]>"], 
-"row": 3, 
+"row": 2, 
 "column": 5,
 "requires": ["Infiltrater Company"],
 },
 {
  "name": "Targeted Insertion", 
 "uniques": ["[+7]% [Production] [in all cities] <for [Infiltrator] units>", "Comment [Increases Mobility of Infiltrator Units]"], 
-"row": 5, 
+"row": 3, 
 "column": 5,
 "requires": ["Tactical Infiltration"],
 },
@@ -77,35 +77,35 @@
  "name": "Friendship", 
 "uniques": [ "[-10]% [Production] [in all cities] <for [Military] units>", "[+10]% [Production] [in all cities] <for [Civilian] units>", "[+1 Happiness] per [4] population [in all cities] <when not at war>"], 
  "row": 1,
- "column": 4, //3
+ "column": 3,
 },
 {
  "name": "Cultural Harmonizing", 
 "uniques": ["[+1 Culture] [in capital]", "[+1 Happiness] per [8] population [in all cities]", "Only available <before adopting [Religous Harmonizing]>"],
 "row": 2,
-"column": 2,
+"column": 1,
  "requires": ["Friendship"],
 },
 {
  "name": "Cultural Amalgamation", 
 "uniques": ["[+1 Culture] [in all cities]", "Only available <before adopting [Religous Harmonizing]>"],
-  "row": 4, //5
-  "column": 2, //4
+  "row": 3,
+  "column": 1,
  
  "requires": ["Cultural Harmonizing"],
 },
 {
  "name": "Religous Harmonizing", 
 "uniques": ["[+1 Happiness, +1 Faith] [in all cities]", "[+1 Faith] [in all cities]", "Only available <before adopting [Cultural Harmonizing]>"], 
-  "row": 2, //4
-  "column": 6, //3
+  "row": 2,
+  "column": 5,
   "requires": ["Friendship"],
 },
 {
  "name": "Religous Acceptance & Tolerance", 
 "uniques": ["[+1 Faith] [in annexed cities]", "[+1 Happiness] [in all non-occupied cities]", "Only available <before adopting [Cultural Harmonizing]>"], 
-   "row": 4, //2
-   "column": 6,   //5
+   "row": 3,
+   "column": 5,
  "requires": ["Religous Harmonizing"],
 },
 { 

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -56,7 +56,7 @@
 {		
 "name": "Jungle Farm",		
 "terrainsCanBeBuiltOn": ["Jungle"],		
-"replaces": ["Farm"]
+"replaces": "Farm",
 "food": 1
 "production": 1
 "turnsToBuild": 5

--- a/jsons/TileResources.json
+++ b/jsons/TileResources.json
@@ -8,10 +8,10 @@
   "improvedBy": ["Mine", "Crystal Drill"],		
 "improvementStats": {"production": 1},	
 	"uniques": ["Guaranteed with Strategic Balance resource option",				
-	"Generated with weight [100] <in [Featureless] [Grassland] tiles>",					
-"Generated with weight [100] <in [Featureless] [Plains] tiles>",					
-"Minor deposits generated with weight [10] <in [Grassland] [Hill] tiles> <in [Snow] [Hill] tiles> ",		
-			"Minor deposits generated with weight [10] <in [Plains] [Hill] tiles> <in tiles without [Forest]> <in tiles without [Jungle]>",				
+	"Generated with weight [100] <in [{Featureless} {Grassland}] tiles>",					
+"Generated with weight [100] <in [{Featureless} {Plains}] tiles>",					
+"Minor deposits generated with weight [10] <in [{Grassland} {Hill}] tiles> <in [{Snow} {Hill}] tiles>",		
+			"Minor deposits generated with weight [10] <in [{Plains} {Hill}] tiles> <in tiles without [Forest]> <in tiles without [Jungle]>",				
 	"Minor deposits generated with weight [100] <in [Grassland] tiles>",					
 "Minor deposits generated with weight [20] <in [Grassland] tiles> <in tiles without [Fresh Water]>",				
 	"Minor deposits generated with weight [30] <in [Plains] tiles>"],	
@@ -26,7 +26,7 @@
 "food": 2,		
 "improvement": "Plantation",		
 "uniques": [
-"Generated on every [7] tiles <in [Featureless] [Grassland] tiles>",			
+"Generated on every [7] tiles <in [{Featureless} {Grassland}] tiles>",			
 "Generated with weight [5] <in [Forest] Regions>",										
 "Generated with weight [5] <in [Hybrid] Regions>",					
 "Generated near City States with weight [15]",					
@@ -67,6 +67,6 @@
 		"terrainsCanBeFoundOn": ["Coast"],
 		"food": 1,
 		"improvement": "Fishing Boats",
-		"uniques": ["Generated on every [10] tiles <in [Featureless] [Coast] tiles> <in [Tundra] Regions>",]
+		"uniques": ["Generated on every [10] tiles <in [{Featureless} {Coast}] tiles> <in [Tundra] Regions>",]
 	},
 ]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -19,7 +19,7 @@
 "[+300]% Strength <during the [Atomic era]>",
 "[+350]% Strength <during the [Information era]>",
 "[+400]% Strength <during the [Future era]>",
-"Only available <for [Ponies]>",
+"Only available <for [Ponies] Civilizations>",
 ],	
 "strength": 10,
 "range": 2,
@@ -96,7 +96,7 @@
 "obsoleteTech": "Plastics",				
 "upgradesTo": "Magical Infantry",	
 "attackSound": "nonmetalhit"	
-"uniques": ["Only available <for [Ponies]>"]
+"uniques": ["Only available <for [Ponies] Civilizations>"]
 },
 {		
 "name": "Magical Rifleman",		
@@ -324,7 +324,7 @@
 "obsoleteTech": "Steel",				
 "upgradesTo": "Longswordsman",		
 "attackSound": "nonmetalhit"	
-"uniques": ["Only available <for [Arctic Nations]>"]
+"uniques": ["Only available <for [Arctic Nations] Civilizations>"]
 },
 {		
 "name": "Farmer Militia",		
@@ -445,7 +445,7 @@
 "obsoleteTech": "Replaceable Parts",				
 "upgradesTo": "Great War Infantry",		
 "attackSound": "nonmetalhit",
-"uniques": ["[+10]% Strength <when fighting in [Tundra] tiles>", "[+10]% Strength <when fighting in [Snow] tiles>", "Only available <for [Ponies]>"]
+"uniques": ["[+10]% Strength <when fighting in [Tundra] tiles>", "[+10]% Strength <when fighting in [Snow] tiles>", "Only available <for [Ponies] Civilizations>"]
 },
 {		
 "name": "Flying Horse Chariot",		
@@ -457,7 +457,7 @@
 "obsoleteTech": "Chivalry",				
 "upgradesTo": "Knight",		
 "attackSound": "nonmetalhit",
-"uniques": ["Only available <for [Ponies]>", "Ignores terrain cost", "Can pass through impassable tiles", ]
+"uniques": ["Only available <for [Ponies] Civilizations>", "Ignores terrain cost", "Can pass through impassable tiles", ]
 },
 {		
 "name": "Unicorn",		
@@ -470,7 +470,7 @@
 "obsoleteTech": "Education",				
 "upgradesTo": "Magician",		
 "attackSound": "nonmetalhit",
-"uniques": ["Only available <for [Ponies]>", "May withdraw before melee ([10]%)"]
+"uniques": ["Only available <for [Ponies] Civilizations>", "Withdraws before melee combat <with [10]% chance>"]
 },
 {		
 "name": "Magician",		
@@ -483,7 +483,7 @@
 "obsoleteTech": "Industrialization",				
 "upgradesTo": "Gatling Gun",		
 "attackSound": "nonmetalhit",
-"uniques": ["Only available <for [Ponies]>", "May withdraw before melee ([10]%)"]
+"uniques": ["Only available <for [Ponies] Civilizations>", "Withdraws before melee combat <with [10]% chance>"]
 },
 	{
 		"name": "Chariot Archer",
@@ -537,7 +537,7 @@
 		"strength": 5,
 		"cost": 25,
 		"obsoleteTech": "Scientific Theory",
-		"uniques": ["May upgrade to [Archer] through ruins-like effects", "Never appears as a Barbarian unit", "Unavailable <for [Griffonians]>"],
+		"uniques": ["May upgrade to [Archer] through ruins-like effects", "Never appears as a Barbarian unit", "Unavailable <for [Griffonians] Civilizations>"],
 		"promotions": ["Ignore terrain cost"],
 		"attackSound": "nonmetalhit"
 	},
@@ -548,7 +548,7 @@
 		"strength": 5,
 		"cost": 20,
 		"obsoleteTech": "Scientific Theory",
-		"uniques": ["May upgrade to [Archer] through ruins-like effects", "Never appears as a Barbarian unit", "[+25]% Strength <when defending>", "Only available <for [Griffonians]>"],
+		"uniques": ["May upgrade to [Archer] through ruins-like effects", "Never appears as a Barbarian unit", "[+25]% Strength <when defending>", "Only available <for [Griffonians] Civilizations>"],
 		"promotions": ["Ignore terrain cost", "Sentry"],
 "hurryCostModifier": 20,
 		"attackSound": "horse"
@@ -561,7 +561,7 @@
    "requiredTech": "Horseback Riding",
 		"cost": 85,
 		"obsoleteTech": "Chivalry",
-		"uniques": ["Only available <for [Ponies]>", "Can move after attacking","No defensive terrain bonus","[-25]% Strength <vs cities> <when attacking>"],
+		"uniques": ["Only available <for [Ponies] Civilizations>", "Can move after attacking","No defensive terrain bonus","[-25]% Strength <vs cities> <when attacking>"],
 		"promotions": ["Ignore terrain cost"],
 		"attackSound": "nonmetalhit"
 	},
@@ -575,7 +575,7 @@
 		"requiredResource": "Horses",
 		"upgradesTo": "Knight",
 		"obsoleteTech": "Chivalry",
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities> <when attacking>", "Unavailable <for [Ponies]>"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities> <when attacking>", "Unavailable <for [Ponies] Civilizations>"],
 		"hurryCostModifier": 20,
 		"attackSound": "horse"
 	},
@@ -616,7 +616,7 @@
 		"requiredTech": "Education",
 		"upgradesTo": "Gatling Gun",
 		"obsoleteTech": "Industrialization",
-		"uniques": ["Only available <for [Ponies]>"],
+		"uniques": ["Only available <for [Ponies] Civilizations>"],
 		"attackSound": "nonmetalhit"
 	},
 {
@@ -628,7 +628,7 @@
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
-   "uniques": ["Only available <for [Griffonians]>"],
+   "uniques": ["Only available <for [Griffonians] Civilizations>"],
 		"attackSound": "shot"
 	},
 	{
@@ -653,7 +653,7 @@
 		"strength": 17,
 		"cost": 90,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+50]% Strength <vs [Mounted] units>", "Only available <for [Griffonians]>"],
+		"uniques": ["[+50]% Strength <vs [Mounted] units>", "Only available <for [Griffonians] Civilizations>"],
 		"upgradesTo": "Lancer",
 		"obsoleteTech": "Metallurgy",
 		"attackSound": "metalhit"
@@ -665,7 +665,7 @@
 		"strength": 16,
 		"cost": 90,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+50]% Strength <vs [Mounted] units>", "Unavailable <for [Griffonians]>"],
+		"uniques": ["[+50]% Strength <vs [Mounted] units>", "Unavailable <for [Griffonians] Civilizations>"],
 		"upgradesTo": "Lancer",
 		"obsoleteTech": "Metallurgy",
 		"attackSound": "metalhit"
@@ -679,7 +679,7 @@
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
-   "uniques": ["Unavailable <for [Griffonians]>"],
+   "uniques": ["Unavailable <for [Griffonians] Civilizations>"],
 		"attackSound": "shot"
 	},
 	{
@@ -694,7 +694,7 @@
 		"requiredTech": "Biology",
 		"upgradesTo": "Triplane",
 		"obsoleteTech": "Radar",
-		"uniques": ["[35]% chance to intercept air attacks", "[+100]% Strength <vs [Bomber] units>", "[+100]% Strength <vs [Helicopter] units>", "Only available <for [Griffonians]>"],
+		"uniques": ["[35]% chance to intercept air attacks", "[+100]% Strength <vs [Bomber] units>", "[+100]% Strength <vs [Helicopter] units>", "Only available <for [Griffonians] Civilizations>"],
 		"attackSound": "machinegun"
 	},
 {
@@ -707,7 +707,7 @@
 		"obsoleteTech": "Military Science",
 		"upgradesTo": "Cavalry",
 		"requiredResource": "Horses",
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities> <when attacking>", "Never appears as a Barbarian unit", "Unavailable <for [Griffonians]>"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities> <when attacking>", "Never appears as a Barbarian unit", "Unavailable <for [Griffonians] Civilizations>"],
 		"attackSound": "horse"
 	},
 {
@@ -730,7 +730,7 @@
 		"requiredTech": "Chivalry",
 		"obsoleteTech": "Military Science",
 		"upgradesTo": "Cavalry",
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities> <when attacking>", "Never appears as a Barbarian unit", "Only available <for [Griffonians]>"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities> <when attacking>", "Never appears as a Barbarian unit", "Only available <for [Griffonians] Civilizations>"],
 		"attackSound": "horse"
 	},
 


### PR DESCRIPTION
Updated most things that needed updating, small UI improvement changes in `Policies.json`, small optimization/quality improvements by removal of redundant filtering uniques.

Note: I noticed that "Sentry" is not `"uniqueTo: Nova Griffonia"`; instead it has the `"Only available for Griffonians Civilizations"` Filter, which means other civs with the `"Griffonians"` Unique can also use it (which is good). The other civ that I know of that are Griffonians is the "Griffon Frontier", but it didn't have a Unique Filter. I don't know if you intended the "Sentry"  units to be unique to the civ, or to be a replacement unit (to the basic/common unit) for all civs with the matching Unique Filter - similar to "Cowfilly"?

Advice: it really is useful that you added the `"[species]"` Unique Filters, and it is especially useful for making alternative sprites for units. Example: if you make/added a "`Worker-Ponies.png`" sprite, the "Worker" Unit should look like its' Pony alternative for Any civ with the `"Ponies"` Unique, while the vanilla civs can keep using the original sprite for that unit. That way, units like "Magical Rifleman" - that are available to all - can have its' human alternative as its default sprite and should appear as such when vanilla civs use them. You can also do "`[Unit]-[Civ]`" when you wanna make an alternative sprite specific for that civ; but I worry if that could cause a conflict - example: if you make a Bat Pony alternative sprite for "Worker", will the program have trouble choosing between "`Worker-Ponies`" and "`Worker-Lunar Republic`", or will it be perfectly fine and pick the latter instead - despite the fact that Lunar Republic also has the `"Ponies"` Unique Filter at the same time? 